### PR TITLE
Validate game files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "ini",
  "log 0.4.22",
  "pelite",
+ "regex",
  "reqwest",
  "sandbox",
  "serde",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "sandbox",
  "serde",
  "serde_json",
+ "sha1",
  "shlex",
  "steamnvke",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ shlex = "1.3.0"
 tauri-plugin-log = "2"
 log = "0.4.22"
 regex = "1.11.1"
+sha1 = "0.10"  # Check for the latest version on crates.io
 
 [target.'cfg(windows)'.dependencies]
 sandbox = {git = "https://github.com/LEAGUE-OF-NINE/flying-sandbox-monster"}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,6 @@ reqwest = { version = "0.12.9", features = ["blocking"] }
 zip = "2.2.1"
 steamnvke = { git = "https://github.com/LEAGUE-OF-NINE/steamnvke" }
 pelite = {git = "https://github.com/LEAGUE-OF-NINE/pelite" }
-sandbox = {git = "https://github.com/LEAGUE-OF-NINE/flying-sandbox-monster"}
 tokio = "1.42.0"
 futures = "0.3.31"
 ini = "1.3.0"
@@ -38,6 +37,9 @@ windows-registry = "0.3.0"
 shlex = "1.3.0"
 tauri-plugin-log = "2"
 log = "0.4.22"
+
+[target.'cfg(windows)'.dependencies]
+sandbox = {git = "https://github.com/LEAGUE-OF-NINE/flying-sandbox-monster"}
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = { version = "2.0.0", features = ["deep-link"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -37,6 +37,7 @@ windows-registry = "0.3.0"
 shlex = "1.3.0"
 tauri-plugin-log = "2"
 log = "0.4.22"
+regex = "1.11.1"
 
 [target.'cfg(windows)'.dependencies]
 sandbox = {git = "https://github.com/LEAGUE-OF-NINE/flying-sandbox-monster"}

--- a/src-tauri/src/commands/checksum.rs
+++ b/src-tauri/src/commands/checksum.rs
@@ -1,8 +1,15 @@
 use reqwest;
 use std::collections::HashMap;
 use std::error::Error;
+use std::fmt::{write, Display, Formatter};
+use std::fs::File;
+use std::io::{Read, Stderr};
+use std::os::unix::prelude::MetadataExt;
+use std::path::PathBuf;
 use std::str::FromStr;
 use regex::Regex;
+use sha1::{Digest, Sha1};
+use crate::commands::checksum::ManifestError::{MismatchedContent, MismatchedType, UnknownFile};
 
 const FOLDER_SHA: &str = "0000000000000000000000000000000000000000";
 
@@ -20,7 +27,84 @@ impl FileInfo {
 
 }
 
-async fn get_manifest() -> Result<HashMap<String, FileInfo>, Box<dyn Error>> {
+struct VersionManifest(HashMap<String, FileInfo>);
+
+#[derive(Debug)]
+enum ManifestError {
+    UnknownFile,
+    MismatchedType{ wanted_dir: bool },
+    MismatchedContent,
+}
+
+impl Display for ManifestError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnknownFile => write!(f, "File is not list in the manifest"),
+            MismatchedType { wanted_dir: true } => write!(f, "Expected directory but got a file"),
+            MismatchedType { wanted_dir: false } => write!(f, "Expected file but got a directory"),
+            MismatchedContent => write!(f, "File does not match the checksum"),
+        }
+    }
+
+}
+
+impl Error for ManifestError {}
+
+fn calculate_checksum(path: PathBuf) -> Result<String, Box<dyn Error>> {
+    // Open the file
+    let mut file = File::open(&path)?;
+
+    // Create a SHA-1 hasher
+    let mut hasher = Sha1::new();
+
+    // Read the file in chunks
+    let mut buffer = [0u8; 1024]; // You can adjust the chunk size as needed
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break; // End of file
+        }
+        hasher.update(&buffer[..bytes_read]);
+    }
+
+    // Finalize the hash and get the hexadecimal representation
+    let result = hasher.finalize();
+    let hex_digest = format!("{:X}", result); // Format as uppercase hexadecimal
+
+    Ok(hex_digest)
+}
+
+impl VersionManifest {
+
+    pub fn check_file(&self, game_dir: &PathBuf, child: &str) -> Result<(), Box<dyn Error>> {
+        let info = match self.0.get(&child.to_string()) {
+            None => return Err(UnknownFile.into()),
+            Some(info) => info,
+        };
+
+        let path = game_dir.join(child);
+        if path.is_dir() != info.is_folder() {
+            return Err(MismatchedType {
+                wanted_dir: info.is_folder(),
+            }.into())
+        }
+
+        if path.is_file() {
+            let metadata = path.metadata()?;
+            if metadata.size() != info.size {
+                return Err(MismatchedContent.into());
+            }
+            if calculate_checksum(path)? != info.sha {
+                return Err(MismatchedContent.into());
+            }
+        }
+
+        Ok(())
+    }
+
+}
+
+async fn get_manifest() -> Result<VersionManifest, Box<dyn Error>> {
     let url = "https://api.lethelc.site/limbus-manifest.txt";
     let response = reqwest::get(url).await?.text().await?;
 
@@ -46,7 +130,7 @@ async fn get_manifest() -> Result<HashMap<String, FileInfo>, Box<dyn Error>> {
         after_header |= header.is_match(line);
     }
 
-    Ok(file_map)
+    Ok(VersionManifest(file_map))
 }
 
 #[cfg(test)]
@@ -56,23 +140,23 @@ mod tests {
     #[tokio::test]
     async fn test_manifest_fetch() -> Result<(), Box<dyn Error>> {
         let manifest = get_manifest().await?;
-        manifest.iter().for_each(|(key, _)| println!("File: {}", key));
+        manifest.0.iter().for_each(|(key, _)| println!("File: {}", key));
 
         // Test that we got some data
-        assert!(!manifest.is_empty(), "Manifest should not be empty");
+        assert!(!manifest.0.is_empty(), "Manifest should not be empty");
 
         // Test for specific known files
-        assert!(manifest.contains_key("GameAssembly.dll"), "Should contain GameAssembly.dll");
-        assert!(manifest.contains_key("LimbusCompany.exe"), "Should contain LimbusCompany.exe");
+        assert!(manifest.0.contains_key("GameAssembly.dll"), "Should contain GameAssembly.dll");
+        assert!(manifest.0.contains_key("LimbusCompany.exe"), "Should contain LimbusCompany.exe");
 
         // Test specific file properties
-        if let Some(game_assembly) = manifest.get("GameAssembly.dll") {
+        if let Some(game_assembly) = manifest.0.get("GameAssembly.dll") {
             assert!(game_assembly.size > 0, "GameAssembly.dll should have non-zero size");
             assert_eq!(game_assembly.sha.len(), 40, "SHA hash should be 40 characters long");
         }
 
         // Print all entries for debugging
-        for (name, info) in &manifest {
+        for (name, info) in &manifest.0 {
             println!("File: {}", name);
             println!("  Size: {}", info.size);
             println!("  SHA:  {}", info.sha);
@@ -81,4 +165,20 @@ mod tests {
 
         Ok(())
     }
+
+
+    #[tokio::test]
+    async fn test_check_file() -> Result<(), Box<dyn Error>> {
+        let manifest = get_manifest().await?;
+        let path = PathBuf::from("Limbus Company/");
+
+        for (name, _) in &manifest.0 {
+            let ok = manifest.check_file(&path, name).is_ok();
+            println!("{}, ok: {}", name, ok);
+        }
+
+        Ok(())
+    }
+
+
 }

--- a/src-tauri/src/commands/checksum.rs
+++ b/src-tauri/src/commands/checksum.rs
@@ -1,0 +1,84 @@
+use reqwest;
+use std::collections::HashMap;
+use std::error::Error;
+use std::str::FromStr;
+use regex::Regex;
+
+const FOLDER_SHA: &str = "0000000000000000000000000000000000000000";
+
+#[derive(Debug)]
+struct FileInfo {
+    size: u64,
+    sha: String,
+}
+
+impl FileInfo {
+
+    fn is_folder(&self) -> bool {
+        self.sha == FOLDER_SHA
+    }
+
+}
+
+async fn get_manifest() -> Result<HashMap<String, FileInfo>, Box<dyn Error>> {
+    let url = "https://api.lethelc.site/limbus-manifest.txt";
+    let response = reqwest::get(url).await?.text().await?;
+
+    let mut file_map = HashMap::new();
+
+    let header = Regex::new(r"^\s*Size\s*Chunks\s*File SHA\s*Flags Name\s*$").unwrap();
+    let mut after_header = false;
+
+    for line in response.lines() {
+        if after_header {
+            if line.len() < 70 {
+                continue
+            }
+
+            let size_str = line[0..14].trim();
+            let sha = line[22..63].trim().to_string();
+            let file_name = line[69..].trim();
+            let size = u64::from_str(size_str)?;
+
+            file_map.insert(file_name.to_string(), FileInfo{ size, sha, });
+        }
+
+        after_header |= header.is_match(line);
+    }
+
+    Ok(file_map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_manifest_fetch() -> Result<(), Box<dyn Error>> {
+        let manifest = get_manifest().await?;
+        manifest.iter().for_each(|(key, _)| println!("File: {}", key));
+
+        // Test that we got some data
+        assert!(!manifest.is_empty(), "Manifest should not be empty");
+
+        // Test for specific known files
+        assert!(manifest.contains_key("GameAssembly.dll"), "Should contain GameAssembly.dll");
+        assert!(manifest.contains_key("LimbusCompany.exe"), "Should contain LimbusCompany.exe");
+
+        // Test specific file properties
+        if let Some(game_assembly) = manifest.get("GameAssembly.dll") {
+            assert!(game_assembly.size > 0, "GameAssembly.dll should have non-zero size");
+            assert_eq!(game_assembly.sha.len(), 40, "SHA hash should be 40 characters long");
+        }
+
+        // Print all entries for debugging
+        for (name, info) in &manifest {
+            println!("File: {}", name);
+            println!("  Size: {}", info.size);
+            println!("  SHA:  {}", info.sha);
+            println!();
+        }
+
+        Ok(())
+    }
+}

--- a/src-tauri/src/commands/file_utils.rs
+++ b/src-tauri/src/commands/file_utils.rs
@@ -1,5 +1,6 @@
 use std::{env, fs, path::Path, time::SystemTime};
-
+use std::path::PathBuf;
+use crate::commands::checksum;
 use super::steam::steam_limbus_location;
 
 fn get_cmd_path() -> Option<String> {
@@ -45,9 +46,20 @@ pub async fn clone_folder_to_game(src_path: String) -> Result<(), String> {
         return Err("LimbusCompany_Data not found in the source directory.".to_string());
     }
 
-    copy_dir_all(src, dest).map_err(|e| format!("Failed to clone folder: {}", e))?;
+    let src_path = PathBuf::from(src);
+    let dst_path = PathBuf::from(dest);
+    let ok = checksum::get_manifest()
+        .await
+        .map_err(|e| e.to_string())?
+        .copy_to_folder(&src_path, &dst_path);
+    if ok.is_err() {
+        // remove LimbusCompany.exe if integrity failed to force the game to be properly copied before launch
+        if let Err(err) = fs::remove_file(dst_path) {
+            log::error!("Failed to delete LimbusCompany.exe on error: {}", err);
+        }
+    }
 
-    Ok(())
+    ok.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -90,25 +102,6 @@ pub fn open_game_folder() -> Result<(), String> {
     Ok(())
 }
 
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> std::io::Result<()> {
-    std::fs::create_dir_all(&dst)?;
-    for entry in std::fs::read_dir(src)? {
-        let entry = entry?;
-        let ty = entry.file_type()?;
-        if ty.is_dir() {
-            copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        } else {
-            std::fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
-        }
-    }
-    Ok(())
-}
-
-fn get_file_modified_time(path: &str) -> std::io::Result<SystemTime> {
-    let metadata = fs::metadata(path)?;
-    metadata.modified()
-}
-
 fn get_lethe_folder_location() -> String {
     let local_appdata = env::var("LOCALAPPDATA").expect("Failed to get LOCALAPPDATA");
     local_appdata + "/Packages/zweilauncher/AC"
@@ -116,15 +109,11 @@ fn get_lethe_folder_location() -> String {
 
 #[tauri::command]
 pub async fn check_new_limbus_version() -> Result<bool, String> {
-    let mut steam_limbus = steam_limbus_location().await;
-    steam_limbus += "/LimbusCompany.exe";
-    let steam_limbus_modified_date =
-        get_file_modified_time(&steam_limbus).map_err(|e| e.to_string())?;
-
-    let lethe_limbus = get_lethe_folder_location() + "/game/LimbusCompany.exe";
-    println!("{}", lethe_limbus);
-    let lethe_limbus_modified_date =
-        get_file_modified_time(&lethe_limbus).map_err(|e| e.to_string())?;
-
-    Ok(lethe_limbus_modified_date < steam_limbus_modified_date)
+    let steam_limbus = steam_limbus_location().await;
+    let steam_path = PathBuf::from(steam_limbus);
+    checksum::get_manifest()
+        .await
+        .map_err(|e| e.to_string())?
+        .check_is_up_to_date(&steam_path)
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/file_utils.rs
+++ b/src-tauri/src/commands/file_utils.rs
@@ -14,9 +14,17 @@ fn get_cmd_path() -> Option<String> {
 
 // Sets up an appcontainer with a placeholder until limbus is installed
 fn setup_app_container() -> Result<(), String> {
-    let cmd_path = get_cmd_path().ok_or("cmd.exe not found")?;
-    sandbox::appcontainer::Profile::new("zweilauncher", &cmd_path).map_err(|e| e.to_string())?;
-    Ok(())
+    #[cfg(target_os = "windows")]
+    {
+        let cmd_path = get_cmd_path().ok_or("cmd.exe not found")?;
+        sandbox::appcontainer::Profile::new("zweilauncher", &cmd_path).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        Err("AppContainer only works on Windows".to_string())
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/file_utils.rs
+++ b/src-tauri/src/commands/file_utils.rs
@@ -1,7 +1,6 @@
-use std::{env, fs, path::Path, time::SystemTime};
-use std::path::PathBuf;
 use crate::commands::checksum;
-use super::steam::steam_limbus_location;
+use std::path::PathBuf;
+use std::{env, fs, path::Path};
 
 fn get_cmd_path() -> Option<String> {
     if let Ok(system_root) = env::var("SystemRoot") {
@@ -18,7 +17,8 @@ fn setup_app_container() -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         let cmd_path = get_cmd_path().ok_or("cmd.exe not found")?;
-        sandbox::appcontainer::Profile::new("zweilauncher", &cmd_path).map_err(|e| e.to_string())?;
+        sandbox::appcontainer::Profile::new("zweilauncher", &cmd_path)
+            .map_err(|e| e.to_string())?;
         Ok(())
     }
 
@@ -102,18 +102,18 @@ pub fn open_game_folder() -> Result<(), String> {
     Ok(())
 }
 
-fn get_lethe_folder_location() -> String {
+fn get_lethe_limbus_folder_location() -> String {
     let local_appdata = env::var("LOCALAPPDATA").expect("Failed to get LOCALAPPDATA");
-    local_appdata + "/Packages/zweilauncher/AC"
+    local_appdata + "/Packages/zweilauncher/AC/game"
 }
 
 #[tauri::command]
-pub async fn check_new_limbus_version() -> Result<bool, String> {
-    let steam_limbus = steam_limbus_location().await;
-    let steam_path = PathBuf::from(steam_limbus);
+pub async fn check_lethe_limbus_up_to_date() -> Result<bool, String> {
+    let lethe_limbus = get_lethe_limbus_folder_location();
+    let lethe_path = PathBuf::from(lethe_limbus);
     checksum::get_manifest()
         .await
         .map_err(|e| e.to_string())?
-        .check_is_up_to_date(&steam_path)
+        .check_is_up_to_date(&lethe_path)
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -28,9 +28,17 @@ pub async fn launch_game(app: AppHandle, launch_args: String, token: String) {
     log::info!("Executing command: {} {}", command, full_args.join(" "));
 
     std::env::set_var("LETHE_TOKEN", token.clone());
-    sandbox::start_game("zweilauncher", &cmd[0..].join(" "));
-    app.emit("launch-status", "Launched... Please wait...")
-        .unwrap();
-    sleep(Duration::from_secs(10)).await;
-    app.emit("launch-status", "").unwrap();
+    #[cfg(target_os = "windows")]
+    {
+        sandbox::start_game("zweilauncher", &cmd[0..].join(" "));
+        app.emit("launch-status", "Launched... Please wait...")
+            .unwrap();
+        sleep(Duration::from_secs(10)).await;
+        app.emit("launch-status", "").unwrap();
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        app.emit("launch-status", "Only supported on Windows currently").unwrap();
+    }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,3 +3,4 @@ pub mod file_utils;
 pub mod game;
 pub mod patch;
 pub mod steam;
+mod checksum;

--- a/src-tauri/src/commands/steam.rs
+++ b/src-tauri/src/commands/steam.rs
@@ -1,16 +1,22 @@
-use std::path::Path;
-use windows_registry::CURRENT_USER;
-
 #[tauri::command]
 pub async fn steam_limbus_location() -> String {
-    CURRENT_USER
-        .create("Software\\Valve\\Steam")
-        .and_then(|key| key.get_string("SteamPath"))
-        .map(|path| {
-            Path::new(&path)
-                .join("steamapps/common/Limbus Company/")
-                .to_string_lossy()
-                .to_string()
-        })
-        .unwrap_or_default()
+    #[cfg(target_os = "windows")]
+    {
+        use windows_registry::CURRENT_USER;
+        CURRENT_USER
+            .create("Software\\Valve\\Steam")
+            .and_then(|key| key.get_string("SteamPath"))
+            .map(|path| {
+                std::path::Path::new(&path)
+                    .join("steamapps/common/Limbus Company/")
+                    .to_string_lossy()
+                    .to_string()
+            })
+            .unwrap_or_default()
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        String::new()
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,5 @@
 use commands::download::{download_and_extract_bepinex, download_and_install_lethe};
-use commands::file_utils::{check_new_limbus_version, clone_folder_to_game, open_game_folder};
+use commands::file_utils::{check_lethe_limbus_up_to_date, clone_folder_to_game, open_game_folder};
 use commands::patch::patch_limbus;
 use commands::steam::steam_limbus_location;
 use std::path::PathBuf;
@@ -52,7 +52,7 @@ pub fn run() {
             patch_limbus,
             open_game_folder,
             clone_folder_to_game,
-            check_new_limbus_version
+            check_lethe_limbus_up_to_date
         ])
         .setup(|app| {
             // Create a new store or load the existing one

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,8 @@ function App() {
 
   async function checkUpdate() {
     try {
-      const response = await invoke<boolean>("check_new_limbus_version");
-      if (response) {
+      const upToDate = await invoke<boolean>("check_lethe_limbus_up_to_date");
+      if (!upToDate) {
         showToast(
           "A new limbus version has been detected. Consider updating.",
           "alert-info",


### PR DESCRIPTION
This PR:
1) Fix compilation on non-windows targets, but important features are not implemented yet 
2) Make the launcher use `https://api.lethelc.site/limbus-manifest.txt` to fetch the game's latest manifest info

The manifest info is used to:
1) Validate if the game is up to date, this replaces the old file modified time check which is unreliable since it can change due to a lot of external factors. Instead it will just check if the checksum of `catalog.json` matches that in the manifest
2) Validate files when copying from the steam folder to the container folder. This is to prevent copying any log files and ensure only files that would be in a fresh install would be copied. This also prevents copying in any corrupted files due to whatever reasons. If the validation check fails then the user would have to go to steam and do "verify files integrity" to fix their install before being able to copy again.

PR currently not tested yet